### PR TITLE
Add user parametrisation

### DIFF
--- a/.github/workflows/github-packages-publish.yml
+++ b/.github/workflows/github-packages-publish.yml
@@ -62,3 +62,4 @@ jobs:
           build-args: |
             DOCKER_VERSION=${{ steps.docker.outputs.version }}
             GIT_VERSION=${{ steps.git.outputs.version }}
+            USER_DOCKER=runner

--- a/.github/workflows/github-packages-publish.yml
+++ b/.github/workflows/github-packages-publish.yml
@@ -63,3 +63,4 @@ jobs:
             DOCKER_VERSION=${{ steps.docker.outputs.version }}
             GIT_VERSION=${{ steps.git.outputs.version }}
             USER_DOCKER=runner
+            USER_REMAP=296608

--- a/.github/workflows/github-packages-publish.yml
+++ b/.github/workflows/github-packages-publish.yml
@@ -62,5 +62,3 @@ jobs:
           build-args: |
             DOCKER_VERSION=${{ steps.docker.outputs.version }}
             GIT_VERSION=${{ steps.git.outputs.version }}
-            USER_DOCKER=runner
-            USER_REMAP=296608

--- a/Dockerfile
+++ b/Dockerfile
@@ -162,7 +162,8 @@ USER ${USER_DOCKER}
 RUN dockerd-rootless-setup-tool.sh install ${DOCKERD_ROOTLESS_INSTALL_FLAGS}
 ENV XDG_RUNTIME_DIR=/home/${USER_DOCKER}/.docker/run \
 		PATH=/usr/local/bin:$PATH \
-		DOCKER_HOST=unix:///home/${USER_DOCKER}/.docker/run/docker.sock
+		DOCKER_HOST=unix:///home/${USER_DOCKER}/.docker/run/docker.sock \
+		USER=${USER_DOCKER}
 
 ENTRYPOINT [ "tini", "-g", "--" ]
 CMD [ "github-actions-entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,12 +55,12 @@ RUN mkdir /run/user && chmod 1777 /run/user
 
 
 # create a default user preconfigured for running rootless dockerd
-RUN adduser --home /home/${USER_DOCKER} --gecos 'Rootless' --disabled-password ${USER_DOCKER}; \
+RUN adduser --home /home/${USER_DOCKER} --gecos 'Rootless' --disabled-password "${USER_DOCKER}"; \
 		echo "${USER_DOCKER}:${USER_REMAP}:65536" >> /etc/subuid; \
 		echo "${USER_DOCKER}:${USER_REMAP}:65536" >> /etc/subgid
 
 # look into guid !!!
-RUN [ "${USER_RUNNER}" != "${USER_DOCKER}" ] && adduser --disabled-password ${USER_RUNNER}
+RUN if test "${USER_RUNNER}" != "${USER_DOCKER}"; then adduser --disabled-password "${USER_RUNNER}"; fi
 
 # Copy our utils to /usr/local/bin
 COPY utils/version.sh utils/git-symlink.sh utils/install-*.sh /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -158,6 +158,8 @@ COPY github-actions-entrypoint.sh runner.sh token.sh dockerd-rootless.sh dockerd
 # /var/run/docker.sock path is hard-coded in the implementation code.
 RUN ln -sf /home/${USER_DOCKER}/.docker/run/docker.sock /var/run/docker.sock
 
+# Change back to the rootless user and make sure the USER environment variable
+# is present and points at the proper user.
 USER ${USER_DOCKER}
 RUN dockerd-rootless-setup-tool.sh install ${DOCKERD_ROOTLESS_INSTALL_FLAGS}
 ENV XDG_RUNTIME_DIR=/home/${USER_DOCKER}/.docker/run \
@@ -165,5 +167,5 @@ ENV XDG_RUNTIME_DIR=/home/${USER_DOCKER}/.docker/run \
 		DOCKER_HOST=unix:///home/${USER_DOCKER}/.docker/run/docker.sock \
 		USER=${USER_DOCKER}
 
-ENTRYPOINT [ "tini", "-g", "--" ]
+ENTRYPOINT [ "tini", "-g", "-s", "--" ]
 CMD [ "github-actions-entrypoint.sh" ]


### PR DESCRIPTION
Add the ability to control the name of the users running the docker daemon and the runner. This is also able to have the same user for both tasks.