### PR TITLE
Feature/same user

### DIFF
--- a/.github/workflows/github-packages-publish.yml
+++ b/.github/workflows/github-packages-publish.yml
@@ -71,3 +71,4 @@ jobs:
           build-args: |
             DOCKER_VERSION=${{ steps.docker.outputs.version }}
             GIT_VERSION=${{ steps.git.outputs.version }}
+            USER_RUNNER=rootless

--- a/.github/workflows/github-packages-publish.yml
+++ b/.github/workflows/github-packages-publish.yml
@@ -71,4 +71,3 @@ jobs:
           build-args: |
             DOCKER_VERSION=${{ steps.docker.outputs.version }}
             GIT_VERSION=${{ steps.git.outputs.version }}
-            USER_RUNNER=rootless

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,11 @@ ARG GH_RUNNER_VERSION="latest"
 ARG COMPOSE_VERSION=latest
 ARG COMPOSE_SWITCH_VERSION=latest
 
-# Name of Users and uid remapping information
+# (Same) name of users and uid remapping information. This seems unfinished
+# business in the original code. Having the same user simplifies usage from
+# alternate build tools, e.g. img.
 ARG USER_DOCKER=rootless
-ARG USER_RUNNER=runner
+ARG USER_RUNNER=rootless
 ARG USER_REMAP=65537
 
 ARG DOCKERD_ROOTLESS_INSTALL_FLAGS


### PR DESCRIPTION
Use same user for runner and rootless, this is almost what the original implementation had (but perhaps didn't mean to?).